### PR TITLE
SHAH-4147 fix WGS-QC error for Breast Cancer Spore samples

### DIFF
--- a/docker/breakpoint/dockerfile_template
+++ b/docker/breakpoint/dockerfile_template
@@ -5,8 +5,8 @@ ADD . /app
 RUN apt-get update --allow-releaseinfo-change && apt install build-essential gcc samtools -y && rm -rf /var/lib/apt/lists/*
 RUN conda install -c bioconda -c dranew destruct==0.4.18 destruct_utils==0.4.20
 RUN rm -rf /opt/conda/lib/python3.7/site-packages/destruct* &&  pip install git+https://github.com/amcpherson/destruct.git@chr_fix
-RUN pip install -e git+https://github.com/amcpherson/blossomv.git#egg=blossomv
-RUN pip install networkx==2.1
+RUN pip install -e git+https://github.com/amcpherson/blossomv.git@download_link_fix#egg=blossomv
+RUN pip install networkx==2.1 scipy
 
 RUN conda install -c bioconda svaba
 

--- a/wgs/workflows/sample_qc/scripts/circos.R
+++ b/wgs/workflows/sample_qc/scripts/circos.R
@@ -18,26 +18,63 @@ fill_cn_data_chroms = function(data, chrom_colname, expected_chroms){
 
 #plot remixt
 plot_remixt = function(copy_number){
-  chroms_needed = c(1:22, "X")
+  print('plot_remixt 1')
+  copy_number$chrom = gsub("chr", "", copy_number$chrom) # chr2 -> 2
   chrom_maxes = rep(-1, length(unique(copy_number$chrom)))
   names(chrom_maxes) = unique(copy_number$chrom)
   for (chrom in names(chrom_maxes)){
+    print('plot_remixt: chrom loop')
+    print(chrom)
     chrom_maxes[chrom] = max(copy_number[copy_number$chrom==chrom, ]$start)
+    #chrom_maxes[chrom] = max(copy_number[copy_number$chrom==chrom, ]$start)
   }
-  chrom_starts = rep(0, length(chrom_maxes)) 
+  print('plot_remixt 2')
+  #chrom_starts = rep(0, length(chroms_needed)) #
+  chrom_starts = rep(0, length(chrom_maxes)) #
+  print('names(chrom_starts)')
+  print(names(chrom_starts))
+  print('chrom_maxes')
+  print(chrom_maxes)
+  print('names(chrom_maxes)')
+  print(names(chrom_maxes))
+  print('length(chrom_maxes)')
+  print(length(chrom_maxes))
+  print('chrom_maxes')
+  print(chrom_maxes)
   names(chrom_starts) = names(chrom_maxes)
+  print('names(chrom_starts) 2')
+  print(names(chrom_starts))
+  print('length(chrom_starts) 2')
+  print(length(chrom_starts))
+  print('chrom_starts 2')
+  print(chrom_starts)
   chrom_positions = c(chrom_starts, chrom_maxes)
+  print('plot_remixt 3')
 
-  circos.track(factors= paste0("chr", copy_number$chrom),
+  circos.track(factors=paste0("chr", copy_number$chrom),
                ylim=c(0, 8), "track.height" = 0.15)
 
+  print('plot_remixt 4')
+  print('chrom_positions')
+  print(chrom_positions)
+  chrom_factors = paste0("chr",names(chrom_positions))
+  print('chrom_factors')
+  print(chrom_factors)
+  print('length(chrom_factors)')
+  print(length(chrom_factors))
+  print('unname(chrom_positions)')
+  print(unname(chrom_positions))
+  print('length(unname(chrom_positions))')
+  print(length(unname(chrom_positions)))
   for (state in 0:8){
-    circos.trackLines(factors = paste0("chr",names(chrom_positions)),
+    circos.trackLines(factors = chrom_factors,
                       x = unname(chrom_positions), 
+                      #y = rep(state, 46), 
                       y = rep(state, length(chrom_positions)), 
                       col="grey")
 
   }
+  print('plot_remixt 5')
 
 
   cn_combined = copy_number
@@ -49,15 +86,18 @@ plot_remixt = function(copy_number){
 
   circos.track(factors= paste0("chr", cn_combined$chrom),
                ylim=c(0, 8), "track.height" = 0.15)
+  print('plot_remixt 6')
   for (state in 0:8){
     circos.trackLines(factors = paste0("chr",names(chrom_positions)),
                       x = unname(chrom_positions), 
-                      y = rep(state, length(chrom_positions)), 
+                      #y = rep(state, 46), 
+                      y = rep(state, length(chrom_positions)), #
                       col="grey")
 
   }
 
 
+  print('plot_remixt 7')
   circos.trackPoints(factors= paste0("chr", copy_number$chrom),
                      x = copy_number$start, y = copy_number$major_raw_e, cex = 0.1, col = "red")
 
@@ -67,27 +107,40 @@ plot_remixt = function(copy_number){
 
 
 plot_titan = function(copy_number){
+  print('plot_titan 1')
   cnCol <- c("#00FF00", "#006400", "#0000FF", "#880000",
              "#BB0000", "#CC0000", "#DD0000", "#EE0000", rep("#FF0000",493))
   names(cnCol) <- c(0:500)
 
-  chroms_needed = c(1:22, "X")
+  copy_number$Chr = gsub("chr", "", copy_number$Chr)
+  chroms_needed = c(1:22, "X", "Y")
   if (! all (chroms_needed %in% copy_number$Chr)){
     copy_number = fill_cn_data_chroms(copy_number, "Chr", chroms_needed)
+    print('plot_titan: copy_number')
+    print(copy_number)
   }
 
   chrom_maxes = rep(-1, length(unique(copy_number$Chr)))
   names(chrom_maxes) = unique(copy_number$Chr)
+  print('plot_titan: chrom_maxes')
+  print(chrom_maxes)
   for (chrom in names(chrom_maxes)){
     chrom_maxes[chrom] = max(copy_number[copy_number$Chr==chrom, ]$Position)
   }
-  chrom_starts = rep(0, 23)
+  print('plot_titan: chrom_maxes 2')
+  print(chrom_maxes)
+  chrom_starts = rep(0, length(chroms_needed))
 
   names(chrom_starts) = names(chrom_maxes)
+  print('plot_titan: chrom_starts')
+  print(chrom_starts)
   chrom_positions = c(chrom_starts, chrom_maxes)
+  print('plot_titan: chrom_positions')
+  print(chrom_positions)
 
   circos.track(factors= paste0("chr", copy_number$Chr),
                ylim=c(0, 8), "track.height" = 0.15)
+  print('plot_titan 2')
 
   for (state in 0:8){
     circos.trackLines(factors = paste0("chr",names(chrom_positions)),
@@ -95,6 +148,7 @@ plot_titan = function(copy_number){
                       y = rep(state, length(chrom_positions)), 
                       col="grey")
   }
+  print('plot_titan 3')
 
   for (state in unique(copy_number$state)){
       x = copy_number$Position[copy_number$state == state]
@@ -103,6 +157,7 @@ plot_titan = function(copy_number){
       col = cnCol[state+1]
       circos.trackPoints(factors= paste0("chr", f),  x = x, y = y, cex = 0.1, col=col)
   }
+  print('plot_titan 4')
 
 }
 
@@ -112,12 +167,24 @@ plot_svs = function(svs, palette){
   if (! nrow(svs)){
     return()
   }
+  svs$chromosome_1 = gsub('chr', '', svs$chromosome_1)
+  svs$chromosome_2 = gsub('chr', '', svs$chromosome_2)
   for (sv in 1:nrow(svs)){
     chr1 = paste0("chr", svs[sv, "chromosome_1"])
+    print('plot_svs: chr1')
+    print(chr1)
     chr2 = paste0("chr", svs[sv, "chromosome_2"])
+    print('plot_svs: chr2')
+    print(chr2)
     p1 =  svs[sv, "position_1"]
+    print('plot_svs: p1')
+    print(p1)
     p2 =  svs[sv, "position_2"]
+    print('plot_svs: p2')
+    print(p2)
     color = palette[svs[sv, "rearrangement_type"]]
+    print('plot_svs: color')
+    print(color)
 
     if (chr1 == "chrY" | chr2 == "chrY"){
       next
@@ -176,8 +243,10 @@ add_legend = function(palette, remixt, titan){
 #svs -> sv data.frame
 circos_plot_titan = function(titan, svs, label){
   require(circlize)
+  print('circos_plot_titan 1')
 
-  circos.initializeWithIdeogram(chromosome.index = paste0("chr", c(1:22, "X")))
+  circos.initializeWithIdeogram(chromosome.index = paste0("chr", c(1:22, "X", "Y")))
+  print('circos_plot_titan 2')
   palette = brewer.pal(6, "Set2")
   names(palette) = c("duplication", "deletion", "unbalanced", "balanced", "foldback", "inversion")
 
@@ -187,36 +256,51 @@ circos_plot_titan = function(titan, svs, label){
   par(family="sans")
   add_legend(palette, FALSE, TRUE)
   title(label)
+  print('circos_plot_titan 3')
 }
 
 
 circos_plot_remixt = function(remixt, svs, label){
+  print('circos_plot_remixt 1')
   require(circlize)
 
-  circos.initializeWithIdeogram(chromosome.index = paste0("chr", c(1:22, "X")))
+  print('circos_plot_remixt 2')
+  circos.initializeWithIdeogram(chromosome.index = paste0("chr", c(1:22, "X", "Y")))
+  print('circos_plot_remixt 3')
   palette = brewer.pal(6, "Set2")
   names(palette) = c("duplication", "deletion", "unbalanced", "balanced", "foldback", "inversion")
 
+  print('circos_plot_remixt 4')
   plot_remixt(remixt)
+  print('circos_plot_remixt 5')
   plot_svs(svs, palette)
+  print('circos_plot_remixt 6')
   circos.clear()
+  print('circos_plot_remixt 7')
   par(family="sans")
+  print('circos_plot_remixt 8')
   add_legend(palette, TRUE, FALSE)
+  print('circos_plot_remixt 9')
   title(label)
+  print('circos_plot_remixt 10')
 }
 
 
 
 make_circos_remixt = function(copy_number, svs, outfile, sample_label){
+  print('make_circos_remixt 1')
 
   #save plot to pdf
   pdf(outfile, 8, 9)
+  print('make_circos_remixt 2')
 
   #create plot
   circos_plot_remixt(copy_number, svs, sample_label)
+  print('make_circos_remixt 3')
 
   #turn off pdf
   dev.off()
+  print('make_circos_remixt 4')
 
 }
 
@@ -237,12 +321,16 @@ make_circos_titan = function(copy_number, svs, outfile, sample_label){
 args <- commandArgs(TRUE)
 titan <- read.csv(args[1], sep = "\t")
 titan$Chr <- gsub('x', 'X', titan$Chr)
+titan$Chr <- gsub('y', 'Y', titan$Chr)
 
 remixt <- args[2]
 
+print('main:remixt') # prints out a path str
+print(remixt) #
 if (remixt != "NULL"){
     remixt <- read.csv(args[2], sep = "\t")
     remixt$chrom <- gsub('x', 'X', remixt$chrom)
+    remixt$chrom <- gsub('y', 'Y', remixt$chrom)
 }
 
 sv_calls <- read.csv(args[3], colClasses=c("rearrangement_type"="character"))
@@ -252,7 +340,9 @@ titan_name <- args[5]
 sample_id <- args[6]
 
 
+print('main:remixt 2') # prints out a table - no problem until here
 if (remixt != "NULL"){
+    print('main:just before make_circos_remixt')
     make_circos_remixt(remixt, sv_calls, remixt_name, sample_id)
 
 }

--- a/wgs/workflows/sample_qc/scripts/circos.R
+++ b/wgs/workflows/sample_qc/scripts/circos.R
@@ -24,7 +24,7 @@ plot_remixt = function(copy_number){
   for (chrom in names(chrom_maxes)){
     chrom_maxes[chrom] = max(copy_number[copy_number$chrom==chrom, ]$start)
   }
-  chrom_starts = rep(0, 23)
+  chrom_starts = rep(0, length(chrom_maxes)) 
   names(chrom_starts) = names(chrom_maxes)
   chrom_positions = c(chrom_starts, chrom_maxes)
 
@@ -33,7 +33,9 @@ plot_remixt = function(copy_number){
 
   for (state in 0:8){
     circos.trackLines(factors = paste0("chr",names(chrom_positions)),
-                      x = unname(chrom_positions), y = rep(state, 46), col="grey")
+                      x = unname(chrom_positions), 
+                      y = rep(state, length(chrom_positions)), 
+                      col="grey")
 
   }
 
@@ -49,7 +51,9 @@ plot_remixt = function(copy_number){
                ylim=c(0, 8), "track.height" = 0.15)
   for (state in 0:8){
     circos.trackLines(factors = paste0("chr",names(chrom_positions)),
-                      x = unname(chrom_positions), y = rep(state, 46), col="grey")
+                      x = unname(chrom_positions), 
+                      y = rep(state, length(chrom_positions)), 
+                      col="grey")
 
   }
 
@@ -87,7 +91,9 @@ plot_titan = function(copy_number){
 
   for (state in 0:8){
     circos.trackLines(factors = paste0("chr",names(chrom_positions)),
-                      x = unname(chrom_positions), y = rep(state, 46), col="grey")
+                      x = unname(chrom_positions), 
+                      y = rep(state, length(chrom_positions)), 
+                      col="grey")
   }
 
   for (state in unique(copy_number$state)){


### PR DESCRIPTION
Fixed the following error:
```
Error: Length of data and length of factors differ.
	In addition: Warning message:
	In if (remixt != "NULL") { :
	  the condition has length > 1 and only the first element will be used
```
check https://isabl.shahlab.mskcc.org/?project=94&analysis=28685

The error occurs when a chromosome (21 in this case) does not exist in the `remixt_prepped` input of `circos.R` .

This is again caused by this line [wgs_qc_utils/read_remixt.py at 9ebc76cc6e259d85321152b74792b1299ab13098 · shahcompbio/wgs_qc_utils](https://github.com/shahcompbio/wgs_qc_utils/blob/9ebc76cc6e259d85321152b74792b1299ab13098/wgs_qc_utils/reader/read_remixt.py#L90) which had some remixt lines removed. For this sample, unfortunately all remixt lines of chromosome 21 had been removed by `remixt = remixt[remixt.combined <= 8]`

So as a workaround, I made circos to plot an empty sector for the missing chromosomes